### PR TITLE
add sessionDidLoadWebView to TurboNavigationDelegate

### DIFF
--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -22,6 +22,9 @@ public protocol TurboNavigationDelegate: AnyObject {
 
     /// Optional. Implement to handle when the web view process dies and can't be restored.
     func sessionWebViewProcessDidTerminate(_ session: Session)
+
+    /// Optional. Implement if you need to change the naviagation delegate on the webView (https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#becoming-the-web-views-navigation-delegate)
+    func sessionDidLoadWebView(_ session: Session)
 }
 
 public extension TurboNavigationDelegate {
@@ -41,6 +44,8 @@ public extension TurboNavigationDelegate {
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         completionHandler(.performDefaultHandling, nil)
     }
+
+    func sessionDidLoadWebView(_ session: Session) {}
 
     func sessionWebViewProcessDidTerminate(_ session: Session) {}
 }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -226,4 +226,8 @@ extension TurboNavigator: SessionDelegate {
     public func session(_ session: Session, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         delegate?.didReceiveAuthenticationChallenge(challenge, completionHandler: completionHandler)
     }
+
+    public func sessionDidLoadWebView(_ session: Session) {
+        delegate?.sessionDidLoadWebView(session)
+    }
 }


### PR DESCRIPTION
This change is necessary to allow setting custom delegates on the webView.

https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#becoming-the-web-views-navigation-delegate

> When doing the cold boot visit, Turbo will need to take over as the WKWebView’s navigationDelegate to know when the page loads. After that, it's likely your application will want to become the navigationDelegate so you can have full control over the various methods.